### PR TITLE
popup: fix url

### DIFF
--- a/config/el-get/recipes/popup.rcp
+++ b/config/el-get/recipes/popup.rcp
@@ -1,4 +1,4 @@
 (:name popup
        :type git
-       :url "https://github.com/m2ym/popup-el.git"
+       :url "https://github.com/auto-complete/popup-el.git"
        :features (popup))


### PR DESCRIPTION
popup.el url moves to "https://github.com/auto-complete/popup-el.git".
