### PR TITLE
emacs 24.4 以前のバージョンで magit を読み込まないようにする

### DIFF
--- a/config/packages.el
+++ b/config/packages.el
@@ -102,7 +102,9 @@
 
 ;;; Magit
 ;; 2012-03-24
-(load "config/packages/magit")
+(if (>= emacs-major-version 24)
+    (if (>= emacs-minor-version 4)
+        (load "config/packages/magit")))
 
 
 ;;; rst-mode


### PR DESCRIPTION
Ubuntu 14.04 の emacs24 パッケージでインストールされる emacs では以下のエラーが表示されました。

> Error (el-get): while installing magit: Package magit requires Emacs version 24.4 or higher, but the current Emacs is only version 24.3.1

これを回避するため、emacs 24.4 以前の emacs 使用時には magit を load しないようにしました。