### PR TITLE
除外リスト追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /history
 /ac-comphist.dat
 /filesets-cache.el
+/elpa
+/eln-cache


### PR DESCRIPTION
設定導入後に色々追加されるパッケージのディレクトリを除外
（誤ってGitHubに放り込まないようにする対策）