### PR TITLE
Update define-key to keymap-set for Emacs 29.1 and above

### DIFF
--- a/config/builtins/dired.el
+++ b/config/builtins/dired.el
@@ -29,14 +29,14 @@
            (magit-status (file-name-directory path)))
           ((string-match-p "\\.hg$" path)
            (monky-status (file-name-directory path))))))
-(define-key dired-mode-map "V" 'dired-vc-status)
+(keymap-set dired-mode-map "V" 'dired-vc-status)
 
 ;; グローバルにバインドしているC-M-nとC-M-pを使えるようにする
 ;; 2014-09-04
 (defun dired-disable-move-subdir-key-bindings ()
   (let ((map dired-mode-map))
-    (define-key map (kbd "C-M-n") nil)
-    (define-key map (kbd "C-M-p") nil)))
+    (keymap-set map "C-M-n" nil)
+    (keymap-set map "C-M-p" nil)))
 
 (add-hook 'dired-mode-hook
           '(lambda ()

--- a/config/packages.el
+++ b/config/packages.el
@@ -59,8 +59,8 @@
 (package-ensure-install 'auto-complete)
 (add-hook 'auto-complete-mode-hook
           (lambda ()
-            (define-key ac-completing-map (kbd "C-n") 'ac-next)
-            (define-key ac-completing-map (kbd "C-p") 'ac-previous)))
+            (keymap-set ac-completing-map "C-n" 'ac-next)
+            (keymap-set ac-completing-map "C-p" 'ac-previous)))
 
 
 ;;; Migemo

--- a/config/packages/anzu.el
+++ b/config/packages/anzu.el
@@ -35,9 +35,9 @@
 (setq anzu-use-migemo t)
 
 ;; 標準の置換コマンドを置き換える。
-(define-key global-map (kbd "M-%")   'anzu-query-replace)
-(define-key global-map (kbd "C-M-%") 'anzu-query-replace-regexp)
+(keymap-set global-map "M-%"   'anzu-query-replace)
+(keymap-set global-map "C-M-%" 'anzu-query-replace-regexp)
 
 ;; カーソルのある場所にある単語をカーソルのある範囲内でだけ置換する。
 ;; 2018-01-10
-(define-key global-map (kbd "ESC M-%") 'anzu-query-replace-at-cursor-thing)
+(keymap-set global-map "ESC M-%" 'anzu-query-replace-at-cursor-thing)

--- a/config/packages/ess.el
+++ b/config/packages/ess.el
@@ -26,25 +26,25 @@
           (lambda ()
             ;; _で<-を挿入する機能を無効にする。
             ;; 2019-12-24
-            (define-key ess-mode-map "_" nil)
+            (keymap-set ess-mode-map "_" nil)
             ;; C-c C-iはdeprecatedだしhippie-expandに使っているので無効にする。
             ;; 2019-12-25
-            (define-key ess-mode-map (kbd "C-c C-i") nil)))
+            (keymap-set ess-mode-map "C-c C-i" nil)))
 
 (add-hook 'ess-r-mode-hook
           (lambda ()
             ;; M-?はhelp-for-helpに使っているので無効にする。
             ;; 2020-01-20
-            (define-key ess-r-mode-map (kbd "M-?") nil)))
+            (keymap-set ess-r-mode-map "M-?" nil)))
 
 (add-hook 'inferior-ess-mode-hook
           (lambda ()
             ;; _で<-を挿入する機能を無効にする。
             ;; 2019-12-24
-            (define-key inferior-ess-mode-map "_" nil)
+            (keymap-set inferior-ess-mode-map "_" nil)
             ;; M-?はhelp-for-helpに使っているので無効にする。
             ;; 2019-12-24
-            (define-key inferior-ess-mode-map (kbd "M-?") nil)
+            (keymap-set inferior-ess-mode-map "M-?" nil)
             ;; C-c C-iはdeprecatedだしhippie-expandに使っているので無効にする。
             ;; 2019-12-25
-            (define-key inferior-ess-mode-map (kbd "C-c C-i") nil)))
+            (keymap-set inferior-ess-mode-map "C-c C-i" nil)))

--- a/config/packages/expand-region.el
+++ b/config/packages/expand-region.el
@@ -19,4 +19,4 @@
 
 (package-ensure-install 'expand-region)
 
-(define-key global-map (kbd "C-=") 'er/expand-region)
+(keymap-set global-map (kbd "C-=") 'er/expand-region)

--- a/config/packages/ibus.el
+++ b/config/packages/ibus.el
@@ -20,4 +20,4 @@
 (add-hook 'after-init-hook 'ibus-mode-on)
 (ibus-define-common-key (kbd "C-SPC") nil)
 (ibus-define-common-key (kbd "C-/") nil)
-(define-key global-map (kbd "C-o") 'ibus-toggle)
+(keymap-set global-map "C-o" 'ibus-toggle)

--- a/config/packages/magit.el
+++ b/config/packages/magit.el
@@ -38,8 +38,8 @@
 
 (defun magit-enable-insert-commit-message-from-history ()
   ;; 過去のコミットメッセージを挿入
-  (define-key git-commit-mode-map
-    (kbd "C-c i") 'magit-insert-commit-message-from-history))
+  (keymap-set git-commit-mode-map
+    "C-c i" 'magit-insert-commit-message-from-history))
 (add-hook 'magit-mode-hook 'magit-enable-insert-commit-message-from-history)
 
 ;; diff関連の設定

--- a/config/packages/multiple-cursors.el
+++ b/config/packages/multiple-cursors.el
@@ -19,8 +19,8 @@
 
 (package-ensure-install 'multiple-cursors)
 
-(define-key global-map (kbd "C-[ M-C-e") 'mc/edit-lines)
+(keymap-set global-map "C-[ M-C-e" 'mc/edit-lines)
 
-(define-key global-map (kbd "<C-right>") 'mc/mark-next-like-this)
-(define-key global-map (kbd "<C-left>") 'mc/mark-previous-like-this)
-(define-key global-map (kbd "<C-down>") 'mc/mark-all-like-this)
+(keymap-set global-map "<C-right>" 'mc/mark-next-like-this)
+(keymap-set global-map "<C-left>" 'mc/mark-previous-like-this)
+(keymap-set global-map "<C-down>" 'mc/mark-all-like-this)

--- a/config/packages/ruby-mode.el
+++ b/config/packages/ruby-mode.el
@@ -43,9 +43,9 @@
             ;; ruby-beginning-of-blockとruby-end-of-blockが
             ;; 上書きしてしまうので無効にする。
             ;; 2012-07-11
-            (define-key ruby-mode-map (kbd "C-M-p") nil)
-            (define-key ruby-mode-map (kbd "C-M-n") nil)
+            (keymap-set ruby-mode-map "C-M-p" nil)
+            (keymap-set ruby-mode-map "C-M-n" nil)
 
             ;; C-c C-eで「end」を挿入する
             ;; 2014-10-28
-            (define-key ruby-mode-map (kbd "C-C C-e") 'ruby-insert-end)))
+            (keymap-set ruby-mode-map "C-C C-e" 'ruby-insert-end)))

--- a/config/packages/uim.el
+++ b/config/packages/uim.el
@@ -28,4 +28,4 @@
     (load-library "uim-var")))
 (setq uim-candidate-display-frame t)
 (setq uim-candidate-display-inline t)
-(define-key global-map "\C-o" 'uim-mode-force-on)
+(keymap-set global-map "\C-o" 'uim-mode-force-on)

--- a/init.el
+++ b/init.el
@@ -39,27 +39,27 @@
 ;; 2012-03-18
 (define-key key-translation-map [?\C-h] [?\C-?])
 ;; 基本
-(define-key global-map (kbd "M-?") 'help-for-help)        ; ヘルプ
-(define-key global-map (kbd "C-z") 'undo)                 ; undo
+(keymap-set global-map "M-?" 'help-for-help)        ; ヘルプ
+(keymap-set global-map "C-z" 'undo)                 ; undo
 ;; 2016-05-06
-(define-key global-map (kbd "C-x C-z") 'repeat)           ; 繰り返し
-(define-key global-map (kbd "C-c C-i") 'hippie-expand)    ; 補完
-(define-key global-map (kbd "C-c ;") 'comment-dwim)       ; コメントアウト
-(define-key global-map (kbd "M-C-g") 'grep)               ; grep
-(define-key global-map (kbd "C-[ M-C-g") 'goto-line)      ; 指定行へ移動
+(keymap-set global-map "C-x C-z" 'repeat)           ; 繰り返し
+(keymap-set global-map "C-c C-i" 'hippie-expand)    ; 補完
+(keymap-set global-map "C-c ;" 'comment-dwim)       ; コメントアウト
+(keymap-set global-map "M-C-g" 'grep)               ; grep
+(keymap-set global-map "C-[ M-C-g" 'goto-line)      ; 指定行へ移動
 ;; 2014-08-31
-(define-key global-map (kbd "C-[ M-C-a") 'align)          ; 整形
+(keymap-set global-map "C-[ M-C-a" 'align)          ; 整形
 ;; 2016-05-06
-(define-key global-map (kbd "C-x C-`") 'next-error)       ; 次のエラーへ
+(keymap-set global-map "C-x C-`" 'next-error)       ; 次のエラーへ
 ;; C-x uでポイント上にあるURLを開く
 ;; 2014-05-18
-(define-key global-map (kbd "C-x u") 'browse-url-at-point)
+(keymap-set global-map "C-x u" 'browse-url-at-point)
 ;; ウィンドウ移動
 ;; 2011-02-17
 ;; 次のウィンドウへ移動
-(define-key global-map (kbd "C-M-n") 'next-multiframe-window)
+(keymap-set global-map "C-M-n" 'next-multiframe-window)
 ;; 前のウィンドウへ移動
-(define-key global-map (kbd "C-M-p") 'previous-multiframe-window)
+(keymap-set global-map "C-M-p" 'previous-multiframe-window)
 ;; 定義へ移動
 ;; 2012-04-15
 ;; C-x F -> 関数定義へ移動
@@ -71,7 +71,7 @@
 ;; 連続で入力してインデントされる方が便利なので同じ使い勝手を実現する
 ;; 2014-11-06
 (if (boundp 'indent-rigidly-map)
-    (define-key indent-rigidly-map (kbd "C-x TAB") 'indent-rigidly-right))
+    (keymap-set indent-rigidly-map "C-x TAB" 'indent-rigidly-right))
 
 
 ;;; grep
@@ -215,7 +215,7 @@
 (require 'dired-x)
 ;; diredから"r"でファイル名をインライン編集する
 (require 'wdired)
-(define-key dired-mode-map "r" 'wdired-change-to-wdired-mode)
+(keymap-set dired-mode-map "r" 'wdired-change-to-wdired-mode)
 
 
 ;;; バッファ名


### PR DESCRIPTION
Emacsの29.1から`define-key`がdeprecatedになる雰囲気なのでアップデート

https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.29.1

- Use 'keymap-set' instead of 'define-key'.
- Use 'keymap-global-set' instead of 'global-set-key'.
- Use 'keymap-local-set' instead of 'local-set-key'.
（略）